### PR TITLE
Added missing name to property, due to xacro error.

### DIFF
--- a/urdf/youbot_base/base.transmission.xacro
+++ b/urdf/youbot_base/base.transmission.xacro
@@ -6,7 +6,6 @@
 
 	<property name="wheel_mechanical_reduction" value="${624/35 * 80/18}" />
 	<property name="caster_mechanical_reduction" value="${624/35 * 80/18}" />
-  <property name="unused_variable_name" value="0.360" />
 
 	<xacro:macro name="youbot_base_transmission">
 	<!-- front left wheel -->

--- a/urdf/youbot_base/base.transmission.xacro
+++ b/urdf/youbot_base/base.transmission.xacro
@@ -6,7 +6,7 @@
 
 	<property name="wheel_mechanical_reduction" value="${624/35 * 80/18}" />
 	<property name="caster_mechanical_reduction" value="${624/35 * 80/18}" />
-  <property name="" value="0.360" />
+  <property name="unused_variable_name" value="0.360" />
 
 	<xacro:macro name="youbot_base_transmission">
 	<!-- front left wheel -->


### PR DESCRIPTION
Trying to use xacro (jade version) gives error, since property name is not set. I've renamed the property, but am unsure if it is actually used (could be better to remove it if not used?).
