### PR TITLE
Remove gazebo_ros_controller from youbot xacro

### DIFF
--- a/robots/youbot.urdf.xacro
+++ b/robots/youbot.urdf.xacro
@@ -59,9 +59,5 @@
   <xacro:hokuyo_urg04_laser name="base_laser_front" parent="base" ros_topic="scan_front" update_rate="10" min_angle="-1.57" max_angle="1.57">
     <origin xyz="0.3 0 -0.03" rpy="0 0 0"/>
   </xacro:hokuyo_urg04_laser>
-
-  <gazebo>
-      <plugin name="gazebo_ros_controller" filename="libgazebo_ros_control.so" />
-  </gazebo>
   
 </robot>


### PR DESCRIPTION
When running the Gazebo simulation in youbot_simulation it doesn't work with Kinetic. This seems to be due to `libgazebo_ros_control.so` being included in both `youbot.urdf.xacro` and `ros_controller.urdf.xacro`. Removing the <gazebo> tag in `youbot.urdf.xacro` seems to solve the issue.