### PR TITLE
Remove duplicate ros_control plugin

### DIFF
--- a/robots/youbot.urdf.xacro
+++ b/robots/youbot.urdf.xacro
@@ -60,8 +60,4 @@
     <origin xyz="0.3 0 -0.03" rpy="0 0 0"/>
   </xacro:hokuyo_urg04_laser>
 
-  <gazebo>
-      <plugin name="gazebo_ros_controller" filename="libgazebo_ros_control.so" />
-  </gazebo>
-  
 </robot>


### PR DESCRIPTION
There was a duplicate ros_control plugin, which made it impossible to
control the base in kinetic.

Steps to reproduce:

```
roslaunch youbot_gazebo_robot youbot.launch
gzclient
rosrun rqt_robot_steering rqt_robot_steering
```

Now try moving the robot around using the rqt_robot_steering GUI.
Without this fix, it doesn't work.

This fixes a bug introduced in afe9ee9d (#4).