### PR TITLE
[Fix][Controller] Legacy mode NS gazebo error

### DIFF
--- a/controller/ros_controller.urdf.xacro
+++ b/controller/ros_controller.urdf.xacro
@@ -4,7 +4,10 @@
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
 
   <gazebo>
-    <plugin name="gazebo_ros_controller" filename="libgazebo_ros_control.so" />
+    <plugin name="gazebo_ros_controller" filename="libgazebo_ros_control.so">
+        <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+        <legacyModeNS>true</legacyModeNS>
+    </plugin>
   </gazebo>
 
 </robot>


### PR DESCRIPTION
When launching youbot arm in gazebo simulator, the following error occurs
```
[ERROR] [1588002645.819598386, 0.315000000]: GazeboRosControlPlugin missing <legacyModeNS> while using DefaultRobotHWSim, defaults to true.
This setting assumes you have an old package with an old implementation of DefaultRobotHWSim, where the robotNamespace is disregarded and absolute paths are used instead.
If you do not want to fix this issue in an old package just set <legacyModeNS> to true.
```

This fix will apply the changes requested in the error by gazebo.