### PR TITLE
Fixed urdf parsing issues

### DIFF
--- a/urdf/sensors/hokuyo_urg04_laser.urdf.xacro
+++ b/urdf/sensors/hokuyo_urg04_laser.urdf.xacro
@@ -14,7 +14,7 @@
       <parent link="${parent}_link"/>
       <child link="${name}_link"/>
     </joint>
-    <link name="${name}_link" type="laser">
+    <link name="${name}_link">
       <inertial>
         <mass value="0.16" />
         <origin xyz="0 0 0" rpy="0 0 0" />

--- a/urdf/youbot_arm/arm.transmission.xacro
+++ b/urdf/youbot_arm/arm.transmission.xacro
@@ -11,7 +11,6 @@
     <transmission name="${name}_trans_1">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_motor_1">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_joint_1">
@@ -22,7 +21,6 @@
     <transmission name="${name}_trans_2">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_motor_2">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_joint_2">
@@ -33,7 +31,6 @@
     <transmission name="${name}_trans_3">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_motor_3">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_joint_3">
@@ -44,7 +41,6 @@
     <transmission name="${name}_trans_4">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_motor_4">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_joint_4">
@@ -55,7 +51,6 @@
     <transmission name="${name}_trans_5">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_motor_5">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_joint_5">

--- a/urdf/youbot_base/base.transmission.xacro
+++ b/urdf/youbot_base/base.transmission.xacro
@@ -12,7 +12,6 @@
     <transmission name="wheel_trans_fl">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="wheel_motor_fl">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${wheel_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="wheel_joint_fl">
@@ -23,7 +22,6 @@
     <transmission name="caster_trans_fl">
       <type>transmission_interface/SimpleTransmission</type>
        <actuator name="caster_motor_fl">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${caster_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="caster_joint_fl">
@@ -35,7 +33,6 @@
     <transmission name="wheel_trans_fr">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="wheel_motor_fr">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${wheel_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="wheel_joint_fr">
@@ -46,7 +43,6 @@
     <transmission name="caster_trans_fr">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="caster_motor_fr" >
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${caster_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="caster_joint_fr">
@@ -58,7 +54,6 @@
     <transmission name="wheel_trans_bl">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="wheel_motor_bl" >
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${wheel_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="wheel_joint_bl">
@@ -69,7 +64,6 @@
     <transmission name="caster_trans_bl">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="caster_motor_bl" >
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${caster_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="caster_joint_bl">
@@ -81,7 +75,6 @@
     <transmission name="wheel_trans_br">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="wheel_motor_br" >
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${wheel_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="wheel_joint_br">
@@ -92,7 +85,6 @@
     <transmission name="caster_trans_br">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="caster_motor_br" >
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${caster_mechanical_reduction}</mechanicalReduction>
       </actuator>
       <joint name="caster_joint_br">

--- a/urdf/youbot_gripper/gripper.transmission.xacro
+++ b/urdf/youbot_gripper/gripper.transmission.xacro
@@ -10,7 +10,6 @@
     <transmission name="${name}_finger_l_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_finger_l_motor">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_finger_joint_l">
@@ -21,7 +20,6 @@
     <transmission name="${name}_finger_r_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_finger_r_motor">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_finger_joint_r">


### PR DESCRIPTION
While parsing urdf, certain tags and attributes were causing the parser to print warnings regarding deprecation.

Source:
http://wiki.ros.org/urdf/XML/Transmission#A.3Ctransmission.3E_Elements
https://github.com/ros/urdf_parser_py/issues/6#issuecomment-278505007

Initial parsing warnings:
```
Scalar element defined multiple times: limit
Unknown tag "hardwareInterface" in /robot[@name='youbot']/transmission[@name='arm_trans_1']/actuator[@name='arm_motor_1']
Unknown tag "hardwareInterface" in /robot[@name='youbot']/transmission[@name='arm_trans_2']/actuator[@name='arm_motor_2']
Unknown tag "hardwareInterface" in /robot[@name='youbot']/transmission[@name='arm_trans_3']/actuator[@name='arm_motor_3']
Unknown tag "hardwareInterface" in /robot[@name='youbot']/transmission[@name='arm_trans_4']/actuator[@name='arm_motor_4']
Unknown tag "hardwareInterface" in /robot[@name='youbot']/transmission[@name='arm_trans_5']/actuator[@name='arm_motor_5']
Unknown attribute "type" in /robot[@name='youbot']/link[@name='base_laser_front_link']
Unknown attribute "type" in /robot[@name='youbot']/link[@name='base_laser_rear_link']
Unknown tag "hardwareInterface" in /robot[@name='youbot']/transmission[@name='gripper_motor_left_trans']/actuator[@name='gripper_motor_left_motor']
Unknown tag "hardwareInterface" in /robot[@name='youbot']/transmission[@name='gripper_motor_right_trans']/actuator[@name='gripper_motor_right_motor']
The root link base_footprint has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
```

After fixes
```
Scalar element defined multiple times: limit
The root link base_footprint has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
```