### PR TITLE
Fix urdf parsing problem with base_footprint having inertia

### DIFF
--- a/urdf/youbot_base/base.urdf.xacro
+++ b/urdf/youbot_base/base.urdf.xacro
@@ -40,26 +40,8 @@
 
 
   <xacro:macro name="youbot_base" params="name">
-    <link name="${name}_footprint">
-      <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 ${-base_size_z / 2.0}" rpy="0 0 0"/>
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
-      </inertial>
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="0.001 0.001 0.001"/>
-        </geometry>
-        <material name="youBot/Red"/>
-      </visual>
-      <collision>
-        <origin xyz="0 0 ${-base_size_z / 2.0}" rpy="0 0 0"/>
-        <geometry>
-          <box size="0.001 0.001 0.001"/>
-        </geometry>
-      </collision>
-    </link>
+    <link name="${name}_footprint"/>
+
     <joint name="${name}_footprint_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <child link="${name}_link"/>


### PR DESCRIPTION
Removed visual, collision and inertial blocks in base_footprint and made it into a dummy link.

The warning was
```
The root link base_footprint has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
```