### PR TITLE
Removed always_on to fix gazebo server segfault

### DIFF
--- a/urdf/sensors/hokuyo_urg04_laser.gazebo.xacro
+++ b/urdf/sensors/hokuyo_urg04_laser.gazebo.xacro
@@ -8,7 +8,6 @@
   <xacro:macro name="hokuyo_urg04_laser_gazebo" params="name ros_topic update_rate min_angle max_angle">
     <gazebo reference="${name}_link">
       <sensor name="${name}" type="ray">
-		<always_on>true</always_on>
         <update_rate>${update_rate}</update_rate>
 		<pose>0 0 0 0 0 0</pose>
 		<visualize>false</visualize>
@@ -30,7 +29,6 @@
 
         <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
             <gaussianNoise>0.005</gaussianNoise>
-            <alwaysOn>true</alwaysOn>
             <updateRate>${update_rate}</updateRate>
             <topicName>${ros_topic}</topicName>
             <frameName>/${name}_link</frameName>


### PR DESCRIPTION
The `always_on` tag in `hokuyo_urg04_laser.gazebo.xacro` was causing gazebo server to segfault. Removing it solves the problem for some reason 🤷🏽‍♂️ 